### PR TITLE
chore: refactor Farcaster ready signal logic for improved initialization

### DIFF
--- a/src/core/components/AppBootstrap.tsx
+++ b/src/core/components/AppBootstrap.tsx
@@ -16,6 +16,14 @@ import {
   ERROR_MESSAGES
 } from '@/src/core/utils/error-handling'
 import { PlatformErrorBoundary } from './ErrorBoundary'
+import { sdk as farcasterSdk } from '@farcaster/miniapp-sdk'
+
+// Signal ready to host app IMMEDIATELY on module evaluation.
+// Must fire before React hydrates — Base App / Warpcast dismiss their
+// splash screen on this signal and have a ~5s timeout from page load.
+if (typeof window !== 'undefined') {
+  farcasterSdk.actions.ready().catch(() => {})
+}
 
 interface BootstrapContextType {
   isBootstrapped: boolean
@@ -79,13 +87,7 @@ export function AppBootstrap({ children, fallback, onReady }: AppBootstrapProps)
           // This ensures the splash screen is dismissed even if platform detection
           // fell back to web platform and MiniKitReady component didn't mount.
           // sdk.actions.ready() is a no-op outside of mini app containers.
-          import('@farcaster/miniapp-sdk').then(({ sdk }) => {
-            sdk.actions.ready().catch(() => {
-              // Not in a mini app context — expected, ignore
-            })
-          }).catch(() => {
-            // Module not available — ignore
-          })
+          farcasterSdk.actions.ready().catch(() => {})
         }
       } catch (err) {
         console.error('[AppBootstrap] Initialization failed:', err)


### PR DESCRIPTION
- Replaced dynamic import with a static import for `@farcaster/miniapp-sdk`.
- Ensured the ready signal is fired immediately during module evaluation to improve splash screen dismissal timing.